### PR TITLE
Link back to speaker info from keynote talks

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -957,11 +957,13 @@ Grafana Labs (author of Grafana product) is a CNCF platinum project sponsor, and
           person: "Vicențiu Ciorbaru"
           location: "Aula Magna"
           photo: "/img/speakers/vicentiu.ciorbaru.jpg"
+          ref: 11
         - name: "Keynote: How I found my voice in open source"
           interval: "09:45"
           person: "Georgiana Dolocan"
           location: "Aula Magna"
           photo: "/img/speakers/georgiana.dolocan.jpg"
+          ref: 15
 
 
     - name: "Coffee / Tea Break"

--- a/themes/hugo-conference/layouts/partials/schedule/schedule-entries.html
+++ b/themes/hugo-conference/layouts/partials/schedule/schedule-entries.html
@@ -20,7 +20,7 @@
                         </div>
                     </td>
                     <td>
-                        {{ .name }}
+                        <a href="#speaker-{{.ref}}" class="speakers-entry-link">{{ .name }}</a>
                     </td>
                 </tr>
             {{ end }}


### PR DESCRIPTION
Previously, only talks that were happening in parallel had links back to the speaker sections.

This change should allow the same behaviour for the keynote talks as well.