### PR TITLE
Add code of conduct section

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,6 +30,7 @@ params:
     - schedule
     - sponsors
     - organizers
+    - conduct
     - contact
 
   # Titles which you can translate to other languages
@@ -42,6 +43,7 @@ params:
     schedule: "Schedule"
     sponsors: "Sponsors"
     organizers: "Organizers"
+    conduct: "Code of Conduct"
     contact: "Contact"
 
   # The Call To Action button at the header,

--- a/themes/hugo-conference/layouts/partials/conduct.html
+++ b/themes/hugo-conference/layouts/partials/conduct.html
@@ -1,0 +1,26 @@
+<h3 class="section-title">{{ .titles.conduct }}</h3>
+
+<p itemprop="description">
+We follow the example and the spirit of <a href="https://fosdem.org/">FOSDEM</a>.
+<br/>
+In order to keep the even a fun, interesting and positive experience for everybody, we expect participants to follow our code of conduct.
+<br/>
+<br/>
+
+OmniOpenCon aims to be a free, open and cooperative event.
+This means we expect collaboration from all the event participants, and for everybody to behave respectfully towards all others, including those that are different or think differently from themselves.
+<br/>
+<br/>
+
+Please be helpful, considerate, friendly, and respectful towards all other participants and respect the environment.
+We don't condone harassment or offensive behaviour at our conference. We consider it against our values as human beings.
+We're voicing our strong, unequivocal support of exemplary behaviour by all participants.
+<br/>
+<br/>
+
+Please bring any concerns to the immediate attention of our coordinating team via the contact methods below or ask any staff member during the event to help you out.
+<br/>
+<br/>
+
+Thank you and remember to have fun! 🤝
+</p>


### PR DESCRIPTION
We'll need to expand this with a dedicated email address/form plus a burner phone number available during the conference. But for the first edition this should do.